### PR TITLE
Revert "updated captagent to 6.2. some features added"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 FROM debian:jessie
 MAINTAINER Lorenzo Mangani
 ENV DEBIAN_FRONTEND noninteractive
-ENV captagent_version 6.2
+ENV captagent_version 6.1
 
-RUN apt-get update -qq && apt-get install --no-install-recommends --no-install-suggests -yqq ca-certificates git make m4 automake autoconf libtool libcap-dev libexpat-dev libpcap-dev zlib1g-dev openssl libssl-dev bison flex  libjson0 libjson0-dev libcurl4-gnutls-dev libjson-c-dev libuv-dev && rm -rf /var/lib/apt/lists/*
+RUN apt-get update -qq && apt-get install --no-install-recommends --no-install-suggests -yqq ca-certificates git make m4 automake autoconf libtool libcap-dev libexpat-dev libpcap-dev zlib1g-dev openssl libssl-dev bison flex  libjson0 libjson0-dev libcurl4-gnutls-dev libjson-c-dev && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/src
-ENV commit f27d59ef77b32ab0b22149c74f87e229261880a2
-RUN git clone https://github.com/sipcapture/captagent.git captagent && cd captagent && git reset --hard $commit
+ENV captagent_sha1 cf757a2e0bb883146e0178d15ee3659c03d9fd6c
+RUN git clone https://github.com/sipcapture/captagent.git captagent && cd captagent && git reset --hard $captagent_sha1
 
 WORKDIR /usr/src/captagent
 RUN ./build.sh

--- a/README.md
+++ b/README.md
@@ -25,21 +25,4 @@ docker build --tag="qxip/captagent-docker:local" ./
 docker run --net=host -t -i qxip/captagent-docker:local
 ```
 
-### Example docker-compose content
-```
-captagent:
-  container_name: captagent
-  image: qxip/captagent-docker
-  restart: always
-  net: host
-  environment:
-    - TERM=xterm
-    - ETHERNET_DEV=any
-    - CAPTURE_HOST=homer.domain.com
-    - CAPTURE_PORT=9060
-    - CAPTURE_PASSWORD=myHep
-    - RTCP_ENABLE=true
-    - RTCP_PORTRANGE=10000-20000
-    - LOG_LEVEL=3
-```
 


### PR DESCRIPTION
Reverts QXIP/captagent-docker#10

`Build failed: stat /var/lib/docker/overlay/afec7b075f8dd3b4540a466ad4d68ec9601199798b8bc98ada26ae14398033be/merged/run.sh: no such file or directory`
