### PR TITLE
NAT_SUPPORT and Config fixes for 6.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ captagent:
     - CAPTURE_PORT=9060
     - CAPTURE_PASSWORD=myHep
     - RTCP_ENABLE=true
-    - RTCP_PORTRANGE=10000-20000
     - LOG_LEVEL=3
     - CAPTURE_ID=1234
     - NAT_SUPPORT=true

--- a/README.md
+++ b/README.md
@@ -42,5 +42,6 @@ captagent:
     - RTCP_PORTRANGE=10000-20000
     - LOG_LEVEL=3
     - CAPTURE_ID=1234
+    - NAT_SUPPORT=true
 ```
 

--- a/run.sh
+++ b/run.sh
@@ -7,7 +7,6 @@ PATH_CAPTAGENT_XML=/usr/local/captagent/etc/captagent/captagent.xml
 PATH_CAPTAGENT_TRANSPORT_XML=/usr/local/captagent/etc/captagent/transport_hep.xml
 PATH_CAPTAGENT_SOCKET_XML=/usr/local/captagent/etc/captagent/socket_pcap.xml
 PATH_CAPTAGENT_DBHASH_XML=/usr/local/captagent/etc/captagent/database_hash.xml
-PATH_SIP_CAPTURE_PLAN=/usr/local/captagent/etc/captagent/captureplans/sip_capture_plan.cfg
 
 # Autogenerate CAPTURE_ID
 export HOSTID=$(printf "%04i\n" 0x$(ip -o link show|grep $(ip route list match 0/0|awk '{print $5}')|grep -m1 -Po 'ether \K[^ ]*'|sed 's,:,,g'))
@@ -20,7 +19,6 @@ CAPTURE_PORT=${CAPTURE_PORT:-9060}
 CAPTURE_ID=${CAPTURE_ID:-${CAPTURE_SET}}
 CAPTURE_PASSWORD=${CAPTURE_PASSWORD:-myHep}
 RTCP_ENABLE=${RTCP_ENABLE:-false}
-RTCP_PORTRANGE=${RTCP_PORTRANGE:-5060-50000}
 LOG_LEVEL=${LOG_LEVEL:-3}
 NAT_SUPPORT=${NAT_SUPPORT:-false}
 
@@ -99,22 +97,18 @@ done
 # Replace values in configuration defaults
 perl -p -i -e "s/debug\" value=\"./debug\" value=\"${LOG_LEVEL}/" $PATH_CAPTAGENT_XML
 
-perl -p -i -e "s/eth0/$ETHERNET_DEV/" $PATH_CAPTAGENT_SOCKET_XML
-perl -p -i -e "s/RTCP Socket\" enable=\"false/RTCP Socket\" enable=\"${RTCP_ENABLE}/i" $PATH_CAPTAGENT_SOCKET_XML
-perl -p -i -e "s/5060-50000/${RTCP_PORTRANGE}/" $PATH_CAPTAGENT_SOCKET_XML
+perl -p -i -e "s/any/$ETHERNET_DEV/" $PATH_CAPTAGENT_SOCKET_XML
+perl -p -i -e "s/RTCP Socket\" enable=\"true/RTCP Socket\" enable=\"${RTCP_ENABLE}/i" $PATH_CAPTAGENT_SOCKET_XML
 
 perl -p -i -e "s/127.0.0.1/$CAPTURE_HOST/" $PATH_CAPTAGENT_TRANSPORT_XML
 perl -p -i -e "s/9061/$CAPTURE_PORT/" $PATH_CAPTAGENT_TRANSPORT_XML
 perl -p -i -e "s/2001/$CAPTURE_ID/" $PATH_CAPTAGENT_TRANSPORT_XML
-perl -p -i -e "s/myHep/$CAPTURE_PASSWORD/i" $PATH_CAPTAGENT_TRANSPORT_XML
+perl -p -i -e "s/myhep/$CAPTURE_PASSWORD/i" $PATH_CAPTAGENT_TRANSPORT_XML
 perl -p -i -e "s/nat-mode\" value=\"false/nat-mode\" value=\"${NAT_SUPPORT}/i" $PATH_CAPTAGENT_DBHASH_XML
+
 
 # perl -p -i -e "s/\{\{ CLI_PORT \}\}/$CLI_PORT/" $PATH_CAPTAGENT_CLI_XML
 # perl -p -i -e "s/\{\{ CLI_PASSWORD \}\}/$CLI_PASSWORD/" $PATH_CAPTAGENT_CLI_XML
-
-# Enable RTCP in sip capture plan.
-[ "${RTCP_ENABLE}" == "true" ] &&\
-echo "$(awk '/sip_has_sdp/{c=8}c-->0{sub("# ?","")} {print}' $PATH_SIP_CAPTURE_PLAN)" > $PATH_SIP_CAPTURE_PLAN
 
 # Finally, run captagent in foreground.
 

--- a/run.sh
+++ b/run.sh
@@ -6,6 +6,7 @@
 PATH_CAPTAGENT_XML=/usr/local/captagent/etc/captagent/captagent.xml
 PATH_CAPTAGENT_TRANSPORT_XML=/usr/local/captagent/etc/captagent/transport_hep.xml
 PATH_CAPTAGENT_SOCKET_XML=/usr/local/captagent/etc/captagent/socket_pcap.xml
+PATH_CAPTAGENT_DBHASH_XML=/usr/local/captagent/etc/captagent/database_hash.xml
 PATH_SIP_CAPTURE_PLAN=/usr/local/captagent/etc/captagent/captureplans/sip_capture_plan.cfg
 
 # Autogenerate CAPTURE_ID
@@ -21,6 +22,7 @@ CAPTURE_PASSWORD=${CAPTURE_PASSWORD:-myHep}
 RTCP_ENABLE=${RTCP_ENABLE:-false}
 RTCP_PORTRANGE=${RTCP_PORTRANGE:-5060-50000}
 LOG_LEVEL=${LOG_LEVEL:-3}
+NAT_SUPPORT=${NAT_SUPPORT:-false}
 
 # Deprecated? Remming out for now...
 # CLI_PASSWORD=${CLI_PASSWORD:-12345}
@@ -105,6 +107,7 @@ perl -p -i -e "s/127.0.0.1/$CAPTURE_HOST/" $PATH_CAPTAGENT_TRANSPORT_XML
 perl -p -i -e "s/9061/$CAPTURE_PORT/" $PATH_CAPTAGENT_TRANSPORT_XML
 perl -p -i -e "s/2001/$CAPTURE_ID/" $PATH_CAPTAGENT_TRANSPORT_XML
 perl -p -i -e "s/myHep/$CAPTURE_PASSWORD/i" $PATH_CAPTAGENT_TRANSPORT_XML
+perl -p -i -e "s/nat-mode\" value=\"false/nat-mode\" value=\"${NAT_SUPPORT}/i" $PATH_CAPTAGENT_DBHASH_XML
 
 # perl -p -i -e "s/\{\{ CLI_PORT \}\}/$CLI_PORT/" $PATH_CAPTAGENT_CLI_XML
 # perl -p -i -e "s/\{\{ CLI_PASSWORD \}\}/$CLI_PASSWORD/" $PATH_CAPTAGENT_CLI_XML


### PR DESCRIPTION
I've added the ability to set the NAT option on database_hash via env NAT_SUPPORT and now builds correctly against latest head version of captagent.